### PR TITLE
Making the editor read only for security

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -22,7 +22,7 @@ const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(({ script, th
     container: editorRef.current,
     theme: theme === 'light' ? vscodeLight : vscodeDark,
     maxHeight: '600px',
-    extensions: [getLanguageExtension(language), EditorView.lineWrapping],
+    extensions: [getLanguageExtension(language), EditorView.lineWrapping, EditorView.editable.of(false)],
     value: script.trim(),
     onChange,
     basicSetup: {


### PR DESCRIPTION
Avoids any malicious code adjustments when using the code runner in the interim.